### PR TITLE
Fix cronjob line splitting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,3 @@ repos:
       - id: ansible-lint
         additional_dependencies:
           - ansible
-        args: [--fix, ]

--- a/ansible/roles/borg/tasks/main.yml
+++ b/ansible/roles/borg/tasks/main.yml
@@ -96,8 +96,4 @@
     hour: "2"
     minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
     user: "{{ ansible_user }}"
-    job: >
-      docker run --rm
-        --network datalab_backend
-        -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh
-        -v /data:/data datalab-borgmatic
+    job: docker run --rm --network datalab_backend -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data datalab-borgmatic # noqa: line-length

--- a/ansible/roles/ssl_first_run/tasks/main.yml
+++ b/ansible/roles/ssl_first_run/tasks/main.yml
@@ -71,6 +71,4 @@
     hour: "10"
     weekday: "2"
     month: "*"
-    job: |
-      docker run --rm -v certbot-www:/var/www/certbot -v certbot-conf:/etc/letsencrypt certbot/certbot:latest renew
-      && docker exec datalab-nginx nginx -s reload
+    job: docker run --rm -v certbot-www:/var/www/certbot -v certbot-conf:/etc/letsencrypt certbot/certbot:latest renew && docker exec datalab-nginx nginx -s reload  # noqa: line-length


### PR DESCRIPTION
Cronjobs in ansible must be one line only. ansible-lint was breaking this.