### PR TITLE
 Disable health check and port specification for node exporter

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -18,8 +18,6 @@
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys
           - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
-        ports:
-          - 9100:9100
         volumes:
           # Mount the host's /proc directory to the container's /host/proc directory
           # This is necessary for the node_exporter to be able to access the host's metrics
@@ -28,12 +26,6 @@
           - /sys:/host/sys:ro
           - /etc/machine-id:/etc/machine-id:ro
           - /etc/timezone:/etc/timezone:ro
-        healthcheck:
-          test: [CMD, wget, -q, --spider, http://localhost:9100/metrics]
-          interval: 30s
-          timeout: 10s
-          retries: 3
-          start_period: 5s
 
     - name: Launch cadvisor container
       community.docker.docker_container:


### PR DESCRIPTION
Prevents errant log messages filling up the disk.