### PR TITLE
Use native `plugins.toml` install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,35 @@ make list
 
 to list all of the available Ansible tags that can be run individually.
 
+#### Installing *datalab* plugins
+
+*datalab* supports first-party and third-party plugins (custom data blocks, etc.) which extend the API server.
+Plugins can be declared in a `plugins.toml` file at the root of the *datalab* repository (alongside `pydatalab/` and `webapp/`) and installed by the `invoke dev.install` task during the API image build; see the upstream [plugins documentation](https://docs.datalab-org.io/en/latest/plugins/) for the file format and the full description of the install procedure.
+
+To install plugins on a server deployed with this repository:
+
+1. Edit the `plugins.toml` at `./src/plugins.toml`.
+   The Ansible role copies it into place on the remote so the Dockerfile picks it up at build time.
+   Example:
+   ```toml
+   dependencies = [
+       "datalab-app-plugin-insitu",
+       "my-local-plugin",
+   ]
+
+   [tool.uv.sources]
+   datalab-app-plugin-insitu = { git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git", rev = "v0.4.1" }
+   my-local-plugin = { path = "pydatalab/plugins/my-local-plugin" }
+   ```
+2. Any local or private plugins can be added as git submodules under `./src/plugins/<plugin-name>/`.
+   These will be synced to the remote; the `plugins.toml` path should then refer to `pydatalab/plugins/<plugin-name>`, which is the corresponding path on the server.
+3. Run `make deploy`.
+   The API container is rebuilt with the plugins baked in.
+   Removing `./src/plugins.toml` and redeploying reverts to the base (plugin-free) lockfile.
+
+> [!WARNING]
+> Plugins run with full API server privileges; only install plugins from sources you trust.
+
 #### Bitwarden integration
 
 Constantly entering the vault password for every attempted deployment can be a

--- a/ansible/roles/datalab/tasks/main.yml
+++ b/ansible/roles/datalab/tasks/main.yml
@@ -19,7 +19,25 @@
     dest: "{{ ansible_user_home_dir }}/datalab/pydatalab"
     recursive: true
     delete: true
-  failed_when: false
+
+- name: Check for plugins.toml
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../src/plugins.toml"
+  register: plugins_toml
+  delegate_to: localhost
+
+- name: Sync plugins.toml to datalab repo root (consumed by API image build)
+  when: plugins_toml.stat.exists
+  ansible.builtin.copy:
+    src: "{{ playbook_dir }}/../src/plugins.toml"
+    dest: "{{ ansible_user_home_dir }}/datalab/plugins.toml"
+    mode: "0644"
+
+- name: Remove stale plugins.toml from remote
+  when: not plugins_toml.stat.exists
+  ansible.builtin.file:
+    path: "{{ ansible_user_home_dir }}/datalab/plugins.toml"
+    state: absent
 
 - name: Check for custom public folder
   ansible.builtin.stat:

--- a/src/plugins.toml
+++ b/src/plugins.toml
@@ -1,0 +1,15 @@
+# Plugin dependencies for this deployment.
+# Consumed by `invoke dev.install` during the API image build; see
+# https://docs.datalab-org.io/en/latest/plugins/ for the format.
+# Paths in [tool.uv.sources] are resolved relative to this file (i.e. the
+# datalab repo root on the remote), so local plugins synced from
+# ./src/plugins/<name>/ in this repo land at pydatalab/plugins/<name>/.
+
+dependencies = [
+    # "datalab-app-plugin-insitu",
+    # "datalab-app-plugin-private",
+]
+
+[tool.uv.sources]
+# datalab-app-plugin-insitu = { git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git", rev = "v0.3.2" }
+# datalab-app-plugin-private = { path = "pydatalab/plugins/datalab-app-plugin-private", editable = true }


### PR DESCRIPTION
Use datalab's new plugins.toml method to install plugins without clobbering commited lock/pyproject files: https://github.com/datalab-org/datalab/pull/1738