### PR TITLE
Add ability to bootstrap non-root user on datalab deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ ungrouped:
       api_url: <desired_datalab_api_url>
       app_url: <desired_datalab_app_url>
       # Additional optional settings:
+      ansible_become_password: <remote_user_password> # (If needed for non-root user)
       mount_data_disk: <disk device file location, e.g., /dev/sda, /dev/sdb or otherwise or a full fstab configuration, e.g., `UUID=aaaa-bbbb-ccc>
       data_disk_type: <the fstype of the data disk, defaults to 'xfs'
       borg_encryption_passphrase: <the passphrase for the borg encryption>

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -4,11 +4,7 @@ ungrouped:
     <hostname>:
       ansible_become_method: sudo
       ansible_user: <remote_username>
-      # Required when ansible_user is not root: used both as the user's
-      # Linux password (set during bootstrap) and as the sudo password
-      # for ansible escalation. Vault-encrypt this value.
       ansible_become_password: <sudo_password>
-
       datalab_prefix: <desired_datalab_prefix (used for monitoring labels)>
       api_url: <desired_datalab_api_url>
       app_url: <desired_datalab_app_url>

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -4,6 +4,11 @@ ungrouped:
     <hostname>:
       ansible_become_method: sudo
       ansible_user: <remote_username>
+      # Required when ansible_user is not root: used both as the user's
+      # Linux password (set during bootstrap) and as the sudo password
+      # for ansible escalation. Vault-encrypt this value.
+      ansible_become_password: <sudo_password>
+
       datalab_prefix: <desired_datalab_prefix (used for monitoring labels)>
       api_url: <desired_datalab_api_url>
       app_url: <desired_datalab_app_url>

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,4 +1,14 @@
 ---
+- name: Bootstrap non-root ansible_user
+  hosts: all
+  gather_facts: true
+  # Connect as root to create the target ansible_user before later plays
+  # connect as it. No-op when ansible_user is already root.
+  remote_user: root
+  roles:
+    - role: bootstrap_user
+      tags: [setup, bootstrap]
+
 - name: Create and maintain a datalab
   hosts: all
   vars:
@@ -17,6 +27,9 @@
     - role: fail2ban
       name: Install and configure fail2ban
       tags: [setup]
+    - role: ssh_hardening
+      name: Disable password SSH and harden sshd
+      tags: [setup, ssh]
     - role: ssl_first_run
       name: Run stripped down nginx and SSL for the first time
       tags: [setup, ssl]

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,8 +3,12 @@
   hosts: all
   gather_facts: true
   # Connect as root to create the target ansible_user before later plays
-  # connect as it. No-op when ansible_user is already root.
-  remote_user: root
+  # connect as it. No-op when ansible_user is already root. Play vars
+  # outrank inventory host_vars, so this overrides them for this play only.
+  vars:
+    target_ansible_user: "{{ ansible_user }}"
+    ansible_user: root
+    ansible_ssh_user: root
   roles:
     - role: bootstrap_user
       tags: [setup, bootstrap]
@@ -13,7 +17,7 @@
   hosts: all
   vars:
     # root behaves differently than other users; set home dir accordingly
-    ansible_user_home_dir: "{{ '/' + ansible_ssh_user if ansible_ssh_user == 'root' else '/home/' + ansible_ssh_user }}"
+    ansible_user_home_dir: "{{ '/' + ansible_user if ansible_user == 'root' else '/home/' + ansible_user }}"
   roles:
     - role: preflight
       name: Check if the system is ready for the playbook

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -2,17 +2,18 @@
 - name: Capture inventory ansible_user before bootstrap overrides it
   hosts: all
   gather_facts: false
+  tags: [setup, bootstrap]
   # set_fact runs locally and doesn't open an SSH connection, so this is
   # safe even when ansible_user can't yet authenticate against the host.
   tasks:
     - name: Stash target ansible_user as a host fact
       ansible.builtin.set_fact:
         target_ansible_user: "{{ ansible_user }}"
-      tags: [setup, bootstrap]
 
 - name: Bootstrap non-root ansible_user
   hosts: all
   gather_facts: true
+  tags: [setup, bootstrap]
   # Connect as root to create the target ansible_user before later plays
   # connect as it. No-op when target_ansible_user is already root. Play
   # vars outrank inventory host_vars, so this overrides them for this play.
@@ -21,7 +22,6 @@
     ansible_ssh_user: root
   roles:
     - role: bootstrap_user
-      tags: [setup, bootstrap]
 
 - name: Create and maintain a datalab
   hosts: all

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,12 +1,22 @@
 ---
+- name: Capture inventory ansible_user before bootstrap overrides it
+  hosts: all
+  gather_facts: false
+  # set_fact runs locally and doesn't open an SSH connection, so this is
+  # safe even when ansible_user can't yet authenticate against the host.
+  tasks:
+    - name: Stash target ansible_user as a host fact
+      ansible.builtin.set_fact:
+        target_ansible_user: "{{ ansible_user }}"
+      tags: [setup, bootstrap]
+
 - name: Bootstrap non-root ansible_user
   hosts: all
   gather_facts: true
   # Connect as root to create the target ansible_user before later plays
-  # connect as it. No-op when ansible_user is already root. Play vars
-  # outrank inventory host_vars, so this overrides them for this play only.
+  # connect as it. No-op when target_ansible_user is already root. Play
+  # vars outrank inventory host_vars, so this overrides them for this play.
   vars:
-    target_ansible_user: "{{ ansible_user }}"
     ansible_user: root
     ansible_ssh_user: root
   roles:
@@ -18,6 +28,11 @@
   vars:
     # root behaves differently than other users; set home dir accordingly
     ansible_user_home_dir: "{{ '/' + ansible_user if ansible_user == 'root' else '/home/' + ansible_user }}"
+  pre_tasks:
+    # Drop any SSH control socket from the bootstrap play so this play
+    # connects fresh as the (possibly different) inventory ansible_user.
+    - name: Reset SSH connection after bootstrap play
+      ansible.builtin.meta: reset_connection
   roles:
     - role: preflight
       name: Check if the system is ready for the playbook

--- a/ansible/roles/bootstrap_user/tasks/main.yml
+++ b/ansible/roles/bootstrap_user/tasks/main.yml
@@ -7,23 +7,26 @@
   ansible.builtin.meta: end_play
   when: target_ansible_user == 'root'
 
-- name: Ensure target user exists
+- name: Require ansible_become_password for non-root bootstrap
+  ansible.builtin.assert:
+    that:
+      - ansible_become_password is defined
+      - ansible_become_password | length > 0
+    fail_msg: >-
+      ansible_become_password must be set (typically via vault) when
+      ansible_user is not root, so the bootstrapped user can sudo.
+
+- name: Ensure target user exists with password set
   become: true
   ansible.builtin.user:
     name: "{{ target_ansible_user }}"
     shell: /bin/bash
     create_home: true
     state: present
-
-- name: Grant passwordless sudo to target user
-  become: true
-  ansible.builtin.copy:
-    dest: "/etc/sudoers.d/90-{{ target_ansible_user }}"
-    content: "{{ target_ansible_user }} ALL=(ALL) NOPASSWD:ALL\n"
-    owner: root
-    group: root
-    mode: "0440"
-    validate: /usr/sbin/visudo -cf %s
+    groups: "{{ 'sudo' if ansible_os_family == 'Debian' else 'wheel' }}"
+    append: true
+    password: "{{ ansible_become_password | password_hash('sha512') }}"
+    update_password: always
 
 - name: Read root's authorized_keys to reuse for target user
   become: true

--- a/ansible/roles/bootstrap_user/tasks/main.yml
+++ b/ansible/roles/bootstrap_user/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 # Bootstraps a non-root ansible_user on a fresh machine.
-# Intended to run from a play that connects as `bootstrap_ssh_user`
-# (typically root) so it can create the user before subsequent plays
-# connect as that user. No-op when ansible_user is root.
-- name: Skip bootstrap when ansible_user is root
+# Intended to run from a play that connects as root, with
+# `target_ansible_user` set to the user that later plays will connect as.
+# No-op when target_ansible_user is root.
+- name: Skip bootstrap when target user is root
   ansible.builtin.meta: end_play
-  when: ansible_user == 'root'
+  when: target_ansible_user == 'root'
 
 - name: Ensure target user exists
   become: true
   ansible.builtin.user:
-    name: "{{ ansible_user }}"
+    name: "{{ target_ansible_user }}"
     shell: /bin/bash
     create_home: true
     state: present
@@ -18,8 +18,8 @@
 - name: Grant passwordless sudo to target user
   become: true
   ansible.builtin.copy:
-    dest: "/etc/sudoers.d/90-{{ ansible_user }}"
-    content: "{{ ansible_user }} ALL=(ALL) NOPASSWD:ALL\n"
+    dest: "/etc/sudoers.d/90-{{ target_ansible_user }}"
+    content: "{{ target_ansible_user }} ALL=(ALL) NOPASSWD:ALL\n"
     owner: root
     group: root
     mode: "0440"
@@ -34,7 +34,7 @@
 - name: Authorize the same SSH keys for target user
   become: true
   ansible.posix.authorized_key:
-    user: "{{ ansible_user }}"
+    user: "{{ target_ansible_user }}"
     key: "{{ root_authorized_keys.content | b64decode }}"
     state: present
 

--- a/ansible/roles/bootstrap_user/tasks/main.yml
+++ b/ansible/roles/bootstrap_user/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# Bootstraps a non-root ansible_user on a fresh machine.
+# Intended to run from a play that connects as `bootstrap_ssh_user`
+# (typically root) so it can create the user before subsequent plays
+# connect as that user. No-op when ansible_user is root.
+- name: Skip bootstrap when ansible_user is root
+  ansible.builtin.meta: end_play
+  when: ansible_user == 'root'
+
+- name: Ensure target user exists
+  become: true
+  ansible.builtin.user:
+    name: "{{ ansible_user }}"
+    shell: /bin/bash
+    create_home: true
+    state: present
+
+- name: Grant passwordless sudo to target user
+  become: true
+  ansible.builtin.copy:
+    dest: "/etc/sudoers.d/90-{{ ansible_user }}"
+    content: "{{ ansible_user }} ALL=(ALL) NOPASSWD:ALL\n"
+    owner: root
+    group: root
+    mode: "0440"
+    validate: /usr/sbin/visudo -cf %s
+
+- name: Read root's authorized_keys to reuse for target user
+  become: true
+  ansible.builtin.slurp:
+    src: /root/.ssh/authorized_keys
+  register: root_authorized_keys
+
+- name: Authorize the same SSH keys for target user
+  become: true
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user }}"
+    key: "{{ root_authorized_keys.content | b64decode }}"
+    state: present
+
+- name: Install uidmap (Debian) for rootless container support
+  become: true
+  when: ansible_os_family == 'Debian'
+  ansible.builtin.apt:
+    name: uidmap
+    state: present
+    update_cache: true
+
+- name: Install shadow-utils (RedHat) for rootless container support
+  become: true
+  when: ansible_os_family == 'RedHat'
+  ansible.builtin.dnf:
+    name: shadow-utils
+    state: present

--- a/ansible/roles/setup/tasks/main.yml
+++ b/ansible/roles/setup/tasks/main.yml
@@ -33,6 +33,7 @@
     pkg:
       - ca-certificates
       - python3-pip
+      - python3-passlib
       - python3.10-venv
     state: present
     update_cache: true

--- a/ansible/roles/ssh_hardening/defaults/main.yml
+++ b/ansible/roles/ssh_hardening/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# When ansible_user is not root, ban root SSH outright. Otherwise allow
+# key-only root login (matches the legacy root-only setup).
+sshd_permit_root_login: "{{ 'no' if ansible_user != 'root' else 'prohibit-password' }}"

--- a/ansible/roles/ssh_hardening/handlers/main.yml
+++ b/ansible/roles/ssh_hardening/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart sshd
+  become: true
+  ansible.builtin.service:
+    name: "{{ 'ssh' if ansible_os_family == 'Debian' else 'sshd' }}"
+    state: restarted

--- a/ansible/roles/ssh_hardening/tasks/main.yml
+++ b/ansible/roles/ssh_hardening/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Drop sshd hardening config
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/10-datalab-hardening.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by datalab-ansible-terraform; do not edit by hand.
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      ChallengeResponseAuthentication no
+      PubkeyAuthentication yes
+      PermitRootLogin {{ sshd_permit_root_login }}
+  notify: Restart sshd
+
+- name: Validate full sshd config
+  become: true
+  ansible.builtin.command: /usr/sbin/sshd -t
+  changed_when: false


### PR DESCRIPTION
Previously, if choosing a non-root user for deployment, the user account had to be made separately on the server. This PR adds a bootstrap role that creates the user and hardens the SSH config to forbid root access.