### PR TITLE
Add borgmatic backup logging via node-exporter

### DIFF
--- a/ansible/roles/borg/defaults/main.yml
+++ b/ansible/roles/borg/defaults/main.yml
@@ -27,9 +27,17 @@ borgmatic_timer_minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
 borg_install_method: package
 borg_require_epel: "{{ ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora' }}"
 
+# Host directory read by node_exporter's textfile collector. The borgmatic
+# container bind-mounts this to /metrics and writes status metrics there.
+borg_textfile_collector_path: /var/lib/node_exporter/textfile_collector
+
 borgmatic_hooks:
   before_backup:
     - echo "`date` - Starting backup."
+  after_backup:
+    - sh -c 'printf "borgmatic_last_success_timestamp_seconds %s\nborgmatic_last_run_status 1\n" "$(date +%s)" > /metrics/borgmatic.prom.tmp && mv /metrics/borgmatic.prom.tmp /metrics/borgmatic.prom'
+  on_error:
+    - sh -c 'printf "borgmatic_last_failure_timestamp_seconds %s\nborgmatic_last_run_status 0\n" "$(date +%s)" > /metrics/borgmatic.prom.tmp && mv /metrics/borgmatic.prom.tmp /metrics/borgmatic.prom'
   mongodb_databases:
     - name: all
       hostname: datalab-database-1

--- a/ansible/roles/borg/defaults/main.yml
+++ b/ansible/roles/borg/defaults/main.yml
@@ -35,9 +35,9 @@ borgmatic_hooks:
   before_backup:
     - echo "`date` - Starting backup."
   after_backup:
-    - sh -c 'printf "borgmatic_last_success_timestamp_seconds %s\nborgmatic_last_run_status 1\n" "$(date +%s)" > /metrics/borgmatic.prom.tmp && mv /metrics/borgmatic.prom.tmp /metrics/borgmatic.prom'
+    - python3 /borgmatic/write-metrics.py success
   on_error:
-    - sh -c 'printf "borgmatic_last_failure_timestamp_seconds %s\nborgmatic_last_run_status 0\n" "$(date +%s)" > /metrics/borgmatic.prom.tmp && mv /metrics/borgmatic.prom.tmp /metrics/borgmatic.prom'
+    - python3 /borgmatic/write-metrics.py error
   mongodb_databases:
     - name: all
       hostname: datalab-database-1

--- a/ansible/roles/borg/files/write-metrics.py
+++ b/ansible/roles/borg/files/write-metrics.py
@@ -21,6 +21,7 @@ def write_atomically(path: str, content: str) -> None:
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
         f.write(content)
+    os.chmod(tmp, 0o644)
     os.rename(tmp, path)
 
 

--- a/ansible/roles/borg/files/write-metrics.py
+++ b/ansible/roles/borg/files/write-metrics.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Write borgmatic status metrics for node_exporter's textfile collector.
+
+Invoked by borgmatic's after_backup / on_error hooks.
+Usage: write-metrics.py {success|error}
+
+Two separate prom files are written so a failed run does not erase the last
+successful run's size metrics. node_exporter merges all *.prom files in the
+textfile directory at scrape time.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+METRICS_DIR = "/metrics"
+
+
+def write_atomically(path: str, content: str) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        f.write(content)
+    os.rename(tmp, path)
+
+
+def collect_repo_stats() -> list[str]:
+    out = subprocess.check_output(
+        ["borgmatic", "info", "--json", "--last", "1"],
+        stderr=subprocess.DEVNULL,
+        timeout=300,
+    )
+    data = json.loads(out)[0]
+    stats = data["cache"]["stats"]
+    lines = [
+        f"borgmatic_repo_unique_size_bytes {stats['unique_csize']}",
+        f"borgmatic_repo_total_size_bytes {stats['total_size']}",
+    ]
+    archives = data.get("archives") or []
+    if archives:
+        a = archives[0]["stats"]
+        lines.extend([
+            f"borgmatic_last_archive_original_size_bytes {a['original_size']}",
+            f"borgmatic_last_archive_compressed_size_bytes {a['compressed_size']}",
+            f"borgmatic_last_archive_deduplicated_size_bytes {a['deduplicated_size']}",
+        ])
+    return lines
+
+
+def main() -> None:
+    status = sys.argv[1] if len(sys.argv) > 1 else "error"
+    ts = int(time.time())
+
+    if status == "success":
+        lines = [f"borgmatic_last_success_timestamp_seconds {ts}"]
+        try:
+            lines.extend(collect_repo_stats())
+        except Exception as e:
+            print(f"borgmatic metrics: failed to capture repo info: {e}", file=sys.stderr)
+        path = os.path.join(METRICS_DIR, "borgmatic-success.prom")
+    else:
+        lines = [f"borgmatic_last_failure_timestamp_seconds {ts}"]
+        path = os.path.join(METRICS_DIR, "borgmatic-failure.prom")
+
+    write_atomically(path, "\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible/roles/borg/files/write-metrics.py
+++ b/ansible/roles/borg/files/write-metrics.py
@@ -29,8 +29,9 @@ def collect_repo_stats() -> list[str]:
         ["borgmatic", "info", "--json", "--last", "1"],
         stderr=subprocess.DEVNULL,
         timeout=300,
-    )
-    data = json.loads(out)[0]
+    ).decode()
+    decoded, _ = json.JSONDecoder().raw_decode(out.lstrip())
+    data = decoded[0] if isinstance(decoded, list) else decoded
     stats = data["cache"]["stats"]
     lines = [
         f"borgmatic_repo_unique_size_bytes {stats['unique_csize']}",

--- a/ansible/roles/borg/tasks/main.yml
+++ b/ansible/roles/borg/tasks/main.yml
@@ -62,4 +62,4 @@
         hour: "2"
         minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
         user: "{{ ansible_user }}"
-        job: timeout 6h docker run --rm --network datalab_backend --name datalab-borgmatic -v {{ ansible_user_home_dir }}/borgmatic/config.yaml:/etc/borgmatic.d/config.yaml -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data -v {{ borg_textfile_collector_path }}:/metrics ghcr.io/borgmatic-collective/borgmatic:2 borgmatic -v 1 # noqa: line-length
+        job: timeout 6h docker run --rm --network datalab_backend --name datalab-borgmatic -v {{ ansible_user_home_dir }}/borgmatic/config.yaml:/etc/borgmatic.d/config.yaml -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data -v {{ ansible_user_home_dir }}/borgmatic:/borgmatic:ro -v {{ borg_textfile_collector_path }}:/metrics ghcr.io/borgmatic-collective/borgmatic:2 borgmatic -v 1 # noqa: line-length

--- a/ansible/roles/borg/tasks/main.yml
+++ b/ansible/roles/borg/tasks/main.yml
@@ -12,6 +12,14 @@
     - borg_encryption_passphrase is defined
     - borg_remote_path is defined
   block:
+
+    - name: Ensure node_exporter textfile collector directory exists
+      become: true
+      ansible.builtin.file:
+        path: "{{ borg_textfile_collector_path }}"
+        state: directory
+        mode: "0755"
+
     - name: Sync local ssh config vault remote
       when: ssh_config.stat.exists
       become: true
@@ -54,4 +62,4 @@
         hour: "2"
         minute: "{{ range(0, 59) | random(seed=inventory_hostname) }}"
         user: "{{ ansible_user }}"
-        job: timeout 6h docker run --rm --network datalab_backend --name datalab-borgmatic -v {{ ansible_user_home_dir }}/borgmatic/config.yaml:/etc/borgmatic.d/config.yaml -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data ghcr.io/borgmatic-collective/borgmatic:2 borgmatic -v 1 # noqa: line-length
+        job: timeout 6h docker run --rm --network datalab_backend --name datalab-borgmatic -v {{ ansible_user_home_dir }}/borgmatic/config.yaml:/etc/borgmatic.d/config.yaml -v {{ ansible_user_home_dir }}/borgmatic/.ssh:/root/.ssh -v /data:/data -v {{ borg_textfile_collector_path }}:/metrics ghcr.io/borgmatic-collective/borgmatic:2 borgmatic -v 1 # noqa: line-length

--- a/ansible/roles/borg/tasks/main.yml
+++ b/ansible/roles/borg/tasks/main.yml
@@ -20,6 +20,18 @@
         state: directory
         mode: "0755"
 
+    - name: Ensure borgmatic config directory exists
+      ansible.builtin.file:
+        path: "{{ ansible_user_home_dir }}/borgmatic"
+        state: directory
+        mode: "0755"
+
+    - name: Copy metrics script
+      ansible.builtin.copy:
+        src: write-metrics.py
+        dest: "{{ ansible_user_home_dir }}/borgmatic/write-metrics.py"
+        mode: "0755"
+
     - name: Sync local ssh config vault remote
       when: ssh_config.stat.exists
       become: true

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -18,6 +18,7 @@
           - --path.procfs=/host/proc
           - --path.sysfs=/host/sys
           - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+          - --collector.textfile.directory=/host/var/lib/node_exporter/textfile_collector
         volumes:
           # Mount the host's /proc directory to the container's /host/proc directory
           # This is necessary for the node_exporter to be able to access the host's metrics


### PR DESCRIPTION
This pull request adds automated Prometheus metrics reporting for borgmatic backup jobs, integrating with node_exporter's textfile collector. The main changes involve introducing a new Python script that records backup status and statistics, updating Ansible roles to deploy and invoke this script, and configuring node_exporter to collect these metrics.

**Borgmatic metrics integration:**

* Added a new script `write-metrics.py` that writes Prometheus-compatible metrics files after each borgmatic backup, capturing backup status (success/error) and repository statistics. This script is invoked by borgmatic's `after_backup` and `on_error` hooks.
* Updated the borgmatic backup job to mount both the metrics directory and the script directory into the borgmatic container, ensuring the script can write metrics to the correct location.