### PR TITLE
Wait for containers to come up on docker launch

### DIFF
--- a/ansible/roles/datalab/tasks/main.yml
+++ b/ansible/roles/datalab/tasks/main.yml
@@ -103,6 +103,8 @@
     profiles: prod
     services: database
     build: always
+    wait: true
+    wait_timeout: 300
 
 - name: Build and launch API container
   community.docker.docker_compose_v2:
@@ -110,6 +112,8 @@
     profiles: prod
     services: api
     build: always
+    wait: true
+    wait_timeout: 300
     env_files:
       - "{{ ansible_user_home_dir }}/datalab/pydatalab/.env"
       - "{{ ansible_user_home_dir }}/datalab/.env_version"
@@ -154,6 +158,8 @@
     profiles: prod
     services: app
     build: always
+    wait: true
+    wait_timeout: 300
     env_files:
       - "{{ ansible_user_home_dir }}/datalab/webapp/.env"
       - "{{ ansible_user_home_dir }}/datalab/.env_version"

--- a/ansible/roles/extras/tasks/main.yml
+++ b/ansible/roles/extras/tasks/main.yml
@@ -27,3 +27,5 @@
       community.docker.docker_compose_v2:
         project_src: "{{ ansible_user_home_dir }}/extras"
         build: always
+        wait: true
+        wait_timeout: 300


### PR DESCRIPTION
Prevents ansible from skipping past when the datalab containers have an unhealthy status.